### PR TITLE
Return gulp stream from styles instead of promise

### DIFF
--- a/packages/sakke/gulpfile.js
+++ b/packages/sakke/gulpfile.js
@@ -218,12 +218,12 @@ function configuredPostcss() {
  * TODO: this should be done some other way (outside of sakke-lib),
  *  since this is project specified
  */
-async function getActiveSakkePluginStyleEntries() {
+function getActiveSakkePluginStyleEntries() {
     return [];
 }
 
-gulp.task("styles", async () => {
-    const pluginStyles = await getActiveSakkePluginStyleEntries();
+gulp.task("styles", () => {
+    const pluginStyles = getActiveSakkePluginStyleEntries();
 
     return gulp
         .src([ROOT + "/assets/styles/*.scss", ...pluginStyles])

--- a/packages/sakke/gulpfile.js
+++ b/packages/sakke/gulpfile.js
@@ -213,20 +213,9 @@ function configuredPostcss() {
     return postcss(plugins);
 }
 
-/**
- * Get standalone css bundles from sakke plugins
- * TODO: this should be done some other way (outside of sakke-lib),
- *  since this is project specified
- */
-function getActiveSakkePluginStyleEntries() {
-    return [];
-}
-
 gulp.task("styles", () => {
-    const pluginStyles = getActiveSakkePluginStyleEntries();
-
     return gulp
-        .src([ROOT + "/assets/styles/*.scss", ...pluginStyles])
+        .src([ROOT + "/assets/styles/*.scss"])
         .pipe(loadSakkePluginStyles())
         .pipe(sourcemaps.init())
         .pipe(sass().on("error", sass.logError))


### PR DESCRIPTION
This pr fix situation where `npx sakke css` does not do anything, but `npx sakke build ` does