### PR TITLE
Fixes valu-tracking-response not going back to 'not-given' status htt…

### DIFF
--- a/packages/3rdparty/src/tracking-consent.ts
+++ b/packages/3rdparty/src/tracking-consent.ts
@@ -205,11 +205,6 @@ export class TrackingConsent {
             return;
         }
 
-        if (this.response.status === "not-given") {
-            window.localStorage.removeItem(this.storeKey);
-            return;
-        }
-
         window.localStorage.setItem(
             this.storeKey,
             JSON.stringify(this.response),


### PR DESCRIPTION
…ps://valu.zendesk.com/agent/tickets/17510

Ongelma toistuu esim. jarvenpaamedia.fi (toistuu myös muissa):
- Hyväksy evästeet
- Poista evästeet footerin linkistä (valitse ok popupista)
- valu-tracking-response-consented on edelleen tilassa ‘consented’ (pitäisi olla jotain muuta, esim. declined tjsp)

Poistamalla commitin rivit tracking consent asettuu oikein 'not-given' -tilaan evästehyväksynnän poistamisen jälkeen.