### PR TITLE
Fix tracking consent falsely consented status

### DIFF
--- a/packages/3rdparty/src/tracking-consent.ts
+++ b/packages/3rdparty/src/tracking-consent.ts
@@ -205,11 +205,6 @@ export class TrackingConsent {
             return;
         }
 
-        if (this.response.status === "not-given") {
-            window.localStorage.removeItem(this.storeKey);
-            return;
-        }
-
         window.localStorage.setItem(
             this.storeKey,
             JSON.stringify(this.response),


### PR DESCRIPTION
How to reproduce:
- Accept cookies
- Remove cookies from the footer link (select ok from the popup)
- valu-tracking-response-consented is still in the state 'consented' (should be empty, "not-given" etc)