### PR TITLE
Force delete CookieBot cookie on forget

### DIFF
--- a/packages/3rdparty/src/cookiebot.ts
+++ b/packages/3rdparty/src/cookiebot.ts
@@ -121,17 +121,7 @@ export function connectCookieBot(
             }
 
             case "forget": {
-                CookiebotScript.now();
-
-                return CookiebotScript.promise().then((cb) => {
-                    debug("Calling CookieBot .renew() to forget consent");
-
-                    // .renew() does not seem to delete the cookie in
-                    // production. So lets do it manually
-                    document.cookie = "CookieConsent=; Max-Age=-99999999;";
-
-                    cb.renew();
-                });
+                document.cookie = "CookieConsent=; Max-Age=-99999999;";
             }
 
             case "request-prompt": {

--- a/packages/3rdparty/src/cookiebot.ts
+++ b/packages/3rdparty/src/cookiebot.ts
@@ -125,6 +125,11 @@ export function connectCookieBot(
 
                 return CookiebotScript.promise().then((cb) => {
                     debug("Calling CookieBot .renew() to forget consent");
+
+                    // .renew() does not seem to delete the cookie in
+                    // production. So lets do it manually
+                    document.cookie = "CookieConsent=; Max-Age=-99999999;";
+
                     cb.renew();
                 });
             }

--- a/packages/3rdparty/src/cookiebot.ts
+++ b/packages/3rdparty/src/cookiebot.ts
@@ -122,6 +122,7 @@ export function connectCookieBot(
 
             case "forget": {
                 document.cookie = "CookieConsent=; Max-Age=-99999999;";
+                return;
             }
 
             case "request-prompt": {


### PR DESCRIPTION
`.renew()` does not seem to remove the cookie in production anymore. So lets just manually remove the cookie.